### PR TITLE
Creating a probe for instrumenting Redis

### DIFF
--- a/gemfiles/Gemfile.base
+++ b/gemfiles/Gemfile.base
@@ -15,4 +15,6 @@ gem 'bson', '~> 1.10'
 unless ENV['SKIP_EXTERNAL']
   gem 'excon'
   gem 'moped'
+  gem 'redis'
+  gem 'fakeredis'
 end

--- a/lib/skylight/probes/redis.rb
+++ b/lib/skylight/probes/redis.rb
@@ -1,0 +1,30 @@
+module Skylight
+  module Probes
+    module Redis
+      class Probe
+        def install
+          ::Redis::Client.class_eval do
+            alias call_without_sk call
+
+            def call(command, &block)
+              command_name = command[0]
+
+              return call_without_sk(command, &block) if command_name == :auth
+
+              opts = {
+                category: "db.redis.command",
+                title:    command_name.upcase.to_s
+              }
+
+              Skylight.instrument(opts) do
+                call_without_sk(command, &block)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    register("Redis", "redis", Redis::Probe.new)
+  end
+end

--- a/spec/integration/probes/redis_spec.rb
+++ b/spec/integration/probes/redis_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'Redis integration', :redis_probe, :redis, :agent do
+
+  before(:each) do
+    @redis = Redis.new
+  end
+
+  it "instruments redis commands" do
+    expected = {
+      category: "db.redis.command",
+      title:    "LRANGE"
+    }
+
+    Skylight.should_receive(:instrument).with(expected).and_call_original
+
+    @redis.lrange("cache:all:the:things", 0, -1)
+  end
+
+  it "does not instrument the AUTH command" do
+    Skylight.should_not_receive(:instrument)
+
+    @redis.auth("secret")
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,10 @@ WebMock.disable!
 begin
   require 'excon'
   require 'skylight/probes/excon'
+
+  require 'redis'
+  require 'fakeredis'
+  require 'skylight/probes/redis'
 rescue LoadError
 end
 

--- a/spec/unit/probes/redis_spec.rb
+++ b/spec/unit/probes/redis_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+module Skylight
+  module Probes
+    describe "Redis:Probe", :redis_probe, :probes do
+
+      it "is registered" do
+        reg = Skylight::Probes.installed["Redis"]
+        reg.klass_name.should == "Redis"
+        reg.require_paths.should == ["redis"]
+        reg.probe.should be_a(Skylight::Probes::Redis::Probe)
+      end
+
+      it "wraps Redis::Client#call" do
+        # This test is somewhat lame
+        ::Redis::Client.instance_methods.should include(:call_without_sk)
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
It took me a while to figure out how to get a Vagrant box up in order to run the tests and start working on it, but here it is.

The way I stubbed out Redis is pretty janky. My understanding is that Redis communicates over a socket, so I tried to figure out how to start a `TCPServer` that Redis could connect to and would respond with `"+OK\r\n"`, which is apparently a successful response in the protocol. But I've never worked directly with sockets before, and I couldn't figure out how to do it short of spinning up a thread so it wouldn't block. So I just stubbed it in such a way that I could expect the write to the socket as it happened.

Thoughts?
