### PR TITLE
Use configured logger during Rails initialization

### DIFF
--- a/lib/skylight/railtie.rb
+++ b/lib/skylight/railtie.rb
@@ -22,13 +22,13 @@ module Skylight
         if config = load_skylight_config(app)
           if Instrumenter.start!(config)
             app.middleware.insert 0, Middleware
-            puts "[SKYLIGHT] [#{Skylight::VERSION}] Skylight agent enabled"
+            config.logger.info "[SKYLIGHT] [#{Skylight::VERSION}] Skylight agent enabled"
           end
         end
       elsif Rails.env.development?
-        puts "[SKYLIGHT] [#{Skylight::VERSION}] Running Skylight in development mode. No data will be reported until you deploy your app."
+        config.logger.info "[SKYLIGHT] [#{Skylight::VERSION}] Running Skylight in development mode. No data will be reported until you deploy your app."
       elsif !Rails.env.test?
-        puts "[SKYLIGHT] [#{Skylight::VERSION}] You are running in the #{Rails.env} environment but haven't added it to config.skylight.environments, so no data will be sent to skylight.io."
+        config.logger.info "[SKYLIGHT] [#{Skylight::VERSION}] You are running in the #{Rails.env} environment but haven't added it to config.skylight.environments, so no data will be sent to skylight.io."
       end
     end
 


### PR DESCRIPTION
In my use case e.g. cron jobs are always silent, unless something fails, in which case cron will send a mail with STDOUT/STDERR. Not using the configured logger results in Skylight printing to STDOUT on every invocation of Rails.
