### PR TITLE
Convenience method for setting endpoint of current trace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,7 @@ gem 'rails', '>= 3.0'
 gem 'sinatra', '>= 1.2.1'
 gem 'grape', '>= 0.10.0'
 
-group :development do
+group :development, :test do
   gem 'yard'
-  gem 'pry'
   gem 'pry-byebug'
 end

--- a/gemfiles/Gemfile.base
+++ b/gemfiles/Gemfile.base
@@ -11,6 +11,10 @@ gem 'rspec', '< 3.0', '> 2.0.0'
 gem 'rspec-collection_matchers'
 gem 'rack-test'
 
+group :development, :test do
+  gem 'pry'
+end
+
 ENV['SKIP_MOPED'] = 'true' if ENV['SKIP_EXTERNAL'] || RUBY_VERSION < '1.9.3'
 
 unless ENV['SKIP_MOPED']

--- a/lib/skylight/core.rb
+++ b/lib/skylight/core.rb
@@ -84,6 +84,12 @@ module Skylight
     inst.done(span)
   end
 
+  # Set a custom name for the endpoint of the current trace
+  def self.set_endpoint(name)
+    return unless inst = Instrumenter.instance
+    inst.current_trace.endpoint = name
+  end
+
   # Instrument
   def self.instrument(opts = DEFAULT_OPTIONS)
     unless inst = Instrumenter.instance

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'timecop'
 require 'beefcake'
 require 'rspec'
 require 'rspec/collection_matchers'
+require 'pry'
 
 require 'webmock/rspec'
 WebMock.disable!


### PR DESCRIPTION
Exposes `Skylight.set_endpoint` method for changing the endpoint of the current trace.