### PR TITLE
Fix Ruby 2.4 build failure due to treating extra semicolon warning as error

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -187,7 +187,7 @@ end
 
 # Some extra checks
 # -Werror is needed for the fast thread local storage
-$CFLAGS << " -Werror"
+$CFLAGS << " -Werror -Wno-error=extra-semi"
 
 checking_for 'fast thread local storage' do
   if try_compile("__thread int foo;")


### PR DESCRIPTION
Extra parens introduced in https://github.com/ruby/ruby/commit/28f5e12c24edda376c863090c09406185373167b for a macro.

Causes skylight build failure since it treats the warning as an error:
```
compiling skylight_memprof.c
In file included from skylight_memprof.c:1:
In file included from /Users/jeremy/.rbenv/versions/2.4.0-dev/include/ruby-2.4.0/ruby.h:33:
In file included from /Users/jeremy/.rbenv/versions/2.4.0-dev/include/ruby-2.4.0/ruby/ruby.h:1998:
/Users/jeremy/.rbenv/versions/2.4.0-dev/include/ruby-2.4.0/ruby/intern.h:485:34: error: extra ';' outside of a function [-Werror,-Wextra-semi]
PUREFUNC(int rb_during_gc(void););
                                 ^
/Users/jeremy/.rbenv/versions/2.4.0-dev/include/ruby-2.4.0/ruby/intern.h:787:41: error: extra ';' outside of a function [-Werror,-Wextra-semi]
PUREFUNC(size_t rb_str_capacity(VALUE););
                                        ^
2 errors generated.
make: *** [skylight_memprof.o] Error 1

make failed, exit code 2
```

Set `-Wno-error=extra-semi` to suppress the error.