### PR TITLE
Add Elasticsearch probe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,14 @@ matrix:
         - MONGOID_VERSION="~> 4.0"
       gemfile: gemfiles/Gemfile.rails-4.2.x
       services: mongodb
+    # Elasticsearch Integration
+    - rvm: 2.3.1
+      env:
+        - TEST_ELASTICSEARCH_INTEGRATION=true
+      gemfile: gemfiles/Gemfile.rails-4.2.x
+      services: elasticsearch
+      before_script:
+        - sleep 10
     # Sinatra
     - rvm: 2.3.1
       gemfile: gemfiles/Gemfile.sinatra-edge

--- a/gemfiles/Gemfile.base
+++ b/gemfiles/Gemfile.base
@@ -51,6 +51,10 @@ unless ENV['SKIP_EXTERNAL']
     end
   end
 
+  unless ENV['SKIP_ELASTICSEARCH']
+    gem 'elasticsearch', ENV['ELASTICSEARCH_VERSION'] || '>= 2.0.0'
+  end
+
   unless ENV['SKIP_TILT'] || ENV['SKIP_SINATRA']
     gem 'tilt', ENV['TILT_VERSION'] || '~> 1.4.1'
   end

--- a/lib/skylight/normalizers.rb
+++ b/lib/skylight/normalizers.rb
@@ -145,6 +145,7 @@ module Skylight
         active_model_serializers/render
         active_record/sql
         active_support/cache
+        elasticsearch/request
         grape/endpoint
         moped/query).each do |file|
       require "skylight/normalizers/#{file}"

--- a/lib/skylight/normalizers/elasticsearch/request.rb
+++ b/lib/skylight/normalizers/elasticsearch/request.rb
@@ -1,0 +1,20 @@
+module Skylight
+  module Normalizers
+    module Elasticsearch
+      class Request < Normalizer
+        register "request.elasticsearch"
+
+        CAT = "db.elasticsearch.request".freeze
+
+        def normalize(trace, name, payload)
+          path = payload[:path].split('/')
+          title = [payload[:method], path[0]].compact.join(' ')
+          desc = {}
+          desc[:type] = path[1] if path[1]
+          desc[:id] = '?' if path[2]
+          [ CAT, title, desc.presence ]
+        end
+      end
+    end
+  end
+end

--- a/lib/skylight/probes/elasticsearch.rb
+++ b/lib/skylight/probes/elasticsearch.rb
@@ -13,7 +13,9 @@ module Skylight
 
                 # Prevent Net::HTTP instrumenter from firing
                 Skylight::Probes::NetHTTP::Probe.disable do
-                  perform_request_without_sk(method, path, *args, &block)
+                  Skylight::Probes::HTTPClient::Probe.disable do
+                    perform_request_without_sk(method, path, *args, &block)
+                  end
                 end
               end
             end

--- a/lib/skylight/probes/elasticsearch.rb
+++ b/lib/skylight/probes/elasticsearch.rb
@@ -1,0 +1,27 @@
+module Skylight
+  module Probes
+    module Elasticsearch
+      class Probe
+        def install
+          ::Elasticsearch::Transport::Transport::Base.class_eval do
+            alias perform_request_without_sk perform_request
+            def perform_request(method, path, *args, &block)
+              ActiveSupport::Notifications.instrument "request.elasticsearch",
+                                                      name:   'Request',
+                                                      method: method,
+                                                      path:   path do
+
+                # Prevent Net::HTTP instrumenter from firing
+                Skylight::Probes::NetHTTP::Probe.disable do
+                  perform_request_without_sk(method, path, *args, &block)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    register("Elasticsearch", "elasticsearch", Elasticsearch::Probe.new)
+  end
+end

--- a/lib/skylight/probes/httpclient.rb
+++ b/lib/skylight/probes/httpclient.rb
@@ -4,6 +4,19 @@ module Skylight
   module Probes
     module HTTPClient
       class Probe
+        DISABLED_KEY = :__skylight_httpclient_disabled
+
+        def self.disable
+          Thread.current[DISABLED_KEY] = true
+          yield
+        ensure
+          Thread.current[DISABLED_KEY] = false
+        end
+
+        def self.disabled?
+          !!Thread.current[DISABLED_KEY]
+        end
+
         def install
           ::HTTPClient.class_eval do
             # HTTPClient has request methods on the class object itself,
@@ -13,6 +26,10 @@ module Skylight
 
             alias do_request_without_sk do_request
             def do_request(method, uri, query, body, header, &block)
+              if Skylight::Probes::HTTPClient::Probe.disabled?
+                return do_request_without_sk(method, uri, query, body, header, &block)
+              end
+
               opts = Formatters::HTTP.build_opts(method, uri.scheme, uri.host, uri.port, uri.path, uri.query)
 
               Skylight.instrument(opts) do

--- a/lib/skylight/probes/net_http.rb
+++ b/lib/skylight/probes/net_http.rb
@@ -6,17 +6,15 @@ module Skylight
       class Probe
         DISABLED_KEY = :__skylight_net_http_disabled
 
-        class << self
-          def disable
-            Thread.current[DISABLED_KEY] = true
-            yield
-          ensure
-            Thread.current[DISABLED_KEY] = false
-          end
+        def self.disable
+          Thread.current[DISABLED_KEY] = true
+          yield
+        ensure
+          Thread.current[DISABLED_KEY] = false
+        end
 
-          def disabled?
-            !!Thread.current[DISABLED_KEY]
-          end
+        def self.disabled?
+          !!Thread.current[DISABLED_KEY]
         end
 
         def install

--- a/spec/integration/probes/elasticsearch_spec.rb
+++ b/spec/integration/probes/elasticsearch_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+# Requires elasticsearch instance to be running
+if ENV['TEST_ELASTICSEARCH_INTEGRATION']
+  describe 'Elasticsearch integration', :elasticsearch_probe, :instrumenter do
+
+    let(:client) do
+      Elasticsearch::Client.new
+    end
+
+    before do
+      # Delete index if it exists
+      Skylight.disable do
+        client.indices.delete(index: 'skylight-test') rescue nil
+      end
+    end
+
+    it "instruments without affecting default instrumenter" do
+      expect(current_trace).to receive(:instrument).with("db.elasticsearch.request", "PUT skylight-test", nil).and_call_original.once
+      client.indices.create(index: 'skylight-test')
+
+      expect(current_trace).to receive(:instrument).with("db.elasticsearch.request", "PUT skylight-test", {type: 'person', id: '?'}).and_call_original.once
+      client.index(index: 'skylight-test', type: 'person', id: '1', body: {name: 'Joe'})
+    end
+  end
+end

--- a/spec/integration/probes/httpclient_spec.rb
+++ b/spec/integration/probes/httpclient_spec.rb
@@ -112,4 +112,15 @@ describe 'HTTPClient integration', :httpclient_probe, :http, :agent do
     expect(response).to be_a(HTTP::Message)
     expect(response).to be_ok
   end
+
+  it "does not instrument when disabled" do
+    expect(Skylight).to_not receive(:instrument)
+
+    Skylight::Probes::HTTPClient::Probe.disable do
+      client = HTTPClient.new
+      response = client.get(uri)
+      expect(response).to be_a(HTTP::Message)
+      expect(response).to be_ok
+    end
+  end
 end

--- a/spec/integration/probes/net_http_spec.rb
+++ b/spec/integration/probes/net_http_spec.rb
@@ -228,4 +228,13 @@ describe 'Net::HTTP integration', :net_http_probe, :http, :agent do
     expect(response2).to be_a(Net::HTTPOK)
   end
 
+  it "does not instrument when disabled" do
+    expect(Skylight).to_not receive(:instrument)
+
+    Skylight::Probes::NetHTTP::Probe.disable do
+      response = Net::HTTP.get_response(uri)
+      expect(response).to be_a(Net::HTTPOK)
+    end
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ if ENV['AMS_VERSION'] == 'edge'
   require 'active_support/inflector'
 end
 
-%w(excon tilt sinatra sequel grape mongo moped mongoid active_model_serializers httpclient).each do |library|
+%w(excon tilt sinatra sequel grape mongo moped mongoid active_model_serializers httpclient elasticsearch).each do |library|
   begin
     require library
     require "skylight/probes/#{library}"

--- a/spec/unit/normalizers/elasticsearch_spec.rb
+++ b/spec/unit/normalizers/elasticsearch_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+module Skylight
+  describe "Normalizers", "request.elasticsearch", :elasticsearch do
+
+    it "normalizes PUT index" do
+      category, title, description = normalize(method: 'PUT', path: 'foo')
+      expect(category).to    eq("db.elasticsearch.request")
+      expect(title).to       eq("PUT foo")
+      expect(description).to be_nil
+    end
+
+    it "normalizes GET type" do
+      category, title, description = normalize(method: 'GET', path: 'foo/bar/baz')
+      expect(category).to    eq("db.elasticsearch.request")
+      expect(title).to       eq("GET foo")
+      expect(description).to eq({type: 'bar', id: '?'})
+    end
+  end
+end


### PR DESCRIPTION
Includes PR #74 since Travis build on master is broken due to latest Grape release.
Also adds disable functionality for Net::HTTP probe, as Elasticsearch uses Net::HTTP.
