### PR TITLE
Fix Travis build for Grape

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,15 +124,15 @@ matrix:
     # Grape
     - rvm: 1.9.2
       env:
-        - GRAPE_VERSION=0.10.0
+        - GRAPE_VERSION=0.17.0
       gemfile: gemfiles/Gemfile.grape
     - rvm: 1.9.3
       env:
-        - GRAPE_VERSION=0.10.0
+        - GRAPE_VERSION=0.17.0
       gemfile: gemfiles/Gemfile.grape
     - rvm: 2.0.0
       env:
-        - GRAPE_VERSION=0.10.0
+        - GRAPE_VERSION=0.17.0
       gemfile: gemfiles/Gemfile.grape
     - rvm: 2.3.1
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,14 @@ matrix:
     - rvm: 2.1.6
       env: SKYLIGHT_DISABLE_AGENT=true
 
+    # Latest Grape does not work on Ruby < 2.1
+    - rvm: 1.9.2
+      gemfile: gemfiles/Gemfile.grape
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile.grape
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile.grape
+
   include:
     # Separate Code Climate coverage run, sort of duplicate of normal Rails 5 job
     - rvm: 2.3.1
@@ -114,6 +122,18 @@ matrix:
     - rvm: 2.3.1
       gemfile: gemfiles/Gemfile.sinatra-edge
     # Grape
+    - rvm: 1.9.2
+      env:
+        - GRAPE_VERSION=0.10.0
+      gemfile: gemfiles/Gemfile.grape
+    - rvm: 1.9.3
+      env:
+        - GRAPE_VERSION=0.10.0
+      gemfile: gemfiles/Gemfile.grape
+    - rvm: 2.0.0
+      env:
+        - GRAPE_VERSION=0.10.0
+      gemfile: gemfiles/Gemfile.grape
     - rvm: 2.3.1
       env:
         - GRAPE_VERSION=0.10.0

--- a/gemfiles/Gemfile.grape
+++ b/gemfiles/Gemfile.grape
@@ -9,7 +9,12 @@ end
 
 gem 'grape', version
 
-# To support 1.9.2
-gem 'activesupport', '< 4.0.0'
-gem 'i18n', '0.6.11'
-gem 'axiom-types', '0.0.5'
+if RUBY_VERSION < '2.2.2'
+  gem 'activesupport', '< 4.0.0'
+end
+
+if RUBY_VERSION < '2.1.0'
+  gem 'axiom-types', '0.0.5'
+  gem 'i18n', '0.6.11'
+  gem 'tool', '< 0.2.0'
+end


### PR DESCRIPTION
Latest Grape has dropped support for Ruby < 2.1. This PR forces older versions of Ruby to use an older version of Grape.