### PR TITLE
Add httpclient probe

### DIFF
--- a/gemfiles/Gemfile.base
+++ b/gemfiles/Gemfile.base
@@ -39,6 +39,7 @@ unless ENV['SKIP_EXTERNAL']
   gem 'excon'
   gem 'redis'
   gem 'fakeredis'
+  gem 'httpclient'
 
   # The dependency bson requires 1.9.3+
   if RUBY_VERSION != '1.9.2'

--- a/lib/skylight/probes/httpclient.rb
+++ b/lib/skylight/probes/httpclient.rb
@@ -2,7 +2,7 @@ require 'skylight/formatters/http'
 
 module Skylight
   module Probes
-    module HTTPClientProbe
+    module HTTPClient
       class Probe
         def install
           ::HTTPClient.class_eval do
@@ -24,6 +24,6 @@ module Skylight
       end # class Probe
     end # module Probes::HTTPClient
 
-    register("HTTPClient", "httpclient", HTTPClientProbe::Probe.new)
+    register("HTTPClient", "httpclient", HTTPClient::Probe.new)
   end
 end

--- a/lib/skylight/probes/httpclient.rb
+++ b/lib/skylight/probes/httpclient.rb
@@ -1,0 +1,29 @@
+require 'skylight/formatters/http'
+
+module Skylight
+  module Probes
+    module HTTPClient
+      class Probe
+        def install
+          ::HTTPClient.class_eval do
+            # HTTPClient has request methods on the class object itself,
+            # but the internally instantiate a client and perform the method
+            # on that, so this instance method override will cover both
+            # `HTTPClient.get(...)` and `HTTPClient.new.get(...)`
+
+            alias do_request_without_sk do_request
+            def do_request(method, uri, query, body, header, &block)
+              opts = Formatters::HTTP.build_opts(method, uri.scheme, uri.host, uri.port, uri.path, uri.query)
+
+              Skylight.instrument(opts) do
+                do_request_without_sk(method, uri, query, body, header, &block)
+              end
+            end
+          end
+        end
+      end # class Probe
+    end # module Probes::HTTPClient
+
+    register("::HTTPClient", "httpclient", HTTPClient::Probe.new)
+  end
+end

--- a/lib/skylight/probes/httpclient.rb
+++ b/lib/skylight/probes/httpclient.rb
@@ -2,7 +2,7 @@ require 'skylight/formatters/http'
 
 module Skylight
   module Probes
-    module HTTPClient
+    module HTTPClientProbe
       class Probe
         def install
           ::HTTPClient.class_eval do
@@ -24,6 +24,6 @@ module Skylight
       end # class Probe
     end # module Probes::HTTPClient
 
-    register("::HTTPClient", "httpclient", HTTPClient::Probe.new)
+    register("HTTPClient", "httpclient", HTTPClientProbe::Probe.new)
   end
 end

--- a/spec/integration/probes/httpclient_spec.rb
+++ b/spec/integration/probes/httpclient_spec.rb
@@ -1,0 +1,115 @@
+require 'spec_helper'
+
+describe 'HTTPClient integration', :httpclient_probe, :http, :agent do
+
+  before(:each) do
+    server.mock "/test.html" do
+      ret = 'Testing'
+      [ 200, { 'content-type' => 'text/plain', 'content-length' => ret.bytesize.to_s }, [ret] ]
+    end
+  end
+
+  def server_uri
+    "http://localhost:#{port}"
+  end
+
+  let :uri do
+    URI.parse("#{server_uri}/test.html")
+  end
+
+  it "instruments get requests" do
+    expected = {
+      category: "api.http.get",
+      title: "GET localhost"
+    }
+
+    expect(Skylight).to receive(:instrument).with(expected).and_call_original
+
+    client = HTTPClient.new
+
+    response = client.get(uri)
+    expect(response).to be_a(HTTP::Message)
+    expect(response).to be_ok
+  end
+
+  it "instruments post requests" do
+    expected = {
+      category: "api.http.post",
+      title: "POST localhost"
+    }
+
+    expect(Skylight).to receive(:instrument).with(expected).and_call_original
+
+    client = HTTPClient.new
+
+    response = client.post(uri, body: "Hi there!")
+    expect(response).to be_a(HTTP::Message)
+    expect(response).to be_ok
+  end
+
+  it "instruments multipart post requests" do
+    expected = {
+      category: "api.http.post",
+      title: "POST localhost"
+    }
+
+    expect(Skylight).to receive(:instrument).with(expected).and_call_original
+
+    client = HTTPClient.new
+
+    response = client.post(uri, header: {"Content-Type" => "multipart/form-data"}, body: [{
+        'Content-Type' => 'text/plain; charset=UTF-8',
+        'Content-Disposition' => 'form-data; name="name"',
+        :content => "Barry"
+      }, {
+        'Content-Type' => 'text/plain; charset=UTF-8',
+        'Content-Disposition' => 'form-data; name="department"',
+        :content => "Accounting"
+      }])
+    expect(response).to be_a(HTTP::Message)
+    expect(response).to be_ok
+  end
+
+  it "instruments head requests" do
+    expected = {
+      category: "api.http.head",
+      title: "HEAD localhost"
+    }
+
+    expect(Skylight).to receive(:instrument).with(expected).and_call_original
+
+    client = HTTPClient.new
+
+    response = client.head(uri)
+    expect(response).to be_a(HTTP::Message)
+    expect(response).to be_ok
+  end
+
+  it "instruments custom method requests" do
+    expected = {
+      category: "api.http.custom",
+      title: "CUSTOM localhost"
+    }
+
+    expect(Skylight).to receive(:instrument).with(expected).and_call_original
+
+    client = HTTPClient.new
+
+    response = client.request("CUSTOM", uri)
+    expect(response).to be_a(HTTP::Message)
+    expect(response).to be_ok
+  end
+
+  it "instruments HTTPClient.methodname static methods" do
+    expected = {
+      category: "api.http.get",
+      title: "GET localhost"
+    }
+
+    expect(Skylight).to receive(:instrument).with(expected).and_call_original
+
+    response = HTTPClient.get(uri)
+    expect(response).to be_a(HTTP::Message)
+    expect(response).to be_ok
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ if ENV['AMS_VERSION'] == 'edge'
   require 'active_support/inflector'
 end
 
-%w(excon tilt sinatra sequel grape mongo moped mongoid active_model_serializers).each do |library|
+%w(excon tilt sinatra sequel grape mongo moped mongoid active_model_serializers httpclient).each do |library|
   begin
     require library
     require "skylight/probes/#{library}"
@@ -94,7 +94,7 @@ Dir[File.expand_path('../support/*.rb', __FILE__)].each do |f|
   require "support/#{File.basename(f, ".rb")}"
 end
 
-all_probes = %w(Excon Net::HTTP Redis Tilt::Template Sinatra::Base Sequel ActionView::TemplateRenderer)
+all_probes = %w(Excon Net::HTTP ::HTTPClient Redis Tilt::Template Sinatra::Base Sequel ActionView::TemplateRenderer)
 installed_probes = Skylight::Probes.installed.keys
 skipped_probes = all_probes - installed_probes
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,7 +94,7 @@ Dir[File.expand_path('../support/*.rb', __FILE__)].each do |f|
   require "support/#{File.basename(f, ".rb")}"
 end
 
-all_probes = %w(Excon Net::HTTP ::HTTPClient Redis Tilt::Template Sinatra::Base Sequel ActionView::TemplateRenderer)
+all_probes = %w(Excon Net::HTTP HTTPClient Redis Tilt::Template Sinatra::Base Sequel ActionView::TemplateRenderer)
 installed_probes = Skylight::Probes.installed.keys
 skipped_probes = all_probes - installed_probes
 

--- a/spec/unit/probes/httpclient_spec.rb
+++ b/spec/unit/probes/httpclient_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+module Skylight
+  module Probes
+    describe "HTTPClient:Probe", :httpclient_probe, :probes do
+
+      it "is registered" do
+        reg = Skylight::Probes.installed["HTTPClient"]
+        expect(reg.klass_name).to eq("HTTPClient")
+        expect(reg.require_paths).to eq(["httpclient"])
+        expect(reg.probe).to be_a(Skylight::Probes::HTTPClient::Probe)
+      end
+
+      it "wraps HTTPClient#do_request" do
+        # This test is somewhat lame
+        expect(::HTTPClient.private_instance_methods).to include(:do_request_without_sk)
+      end
+
+    end
+  end
+end

--- a/spec/unit/probes/httpclient_spec.rb
+++ b/spec/unit/probes/httpclient_spec.rb
@@ -8,12 +8,12 @@ module Skylight
         reg = Skylight::Probes.installed["HTTPClient"]
         expect(reg.klass_name).to eq("HTTPClient")
         expect(reg.require_paths).to eq(["httpclient"])
-        expect(reg.probe).to be_a(Skylight::Probes::HTTPClientProbe::Probe)
+        expect(reg.probe).to be_a(Skylight::Probes::HTTPClient::Probe)
       end
 
       it "wraps HTTPClient#do_request" do
         # This test is somewhat lame
-        expect(HTTPClient.private_instance_methods).to include(:do_request_without_sk)
+        expect(::HTTPClient.private_instance_methods).to include(:do_request_without_sk)
       end
 
     end

--- a/spec/unit/probes/httpclient_spec.rb
+++ b/spec/unit/probes/httpclient_spec.rb
@@ -8,12 +8,12 @@ module Skylight
         reg = Skylight::Probes.installed["HTTPClient"]
         expect(reg.klass_name).to eq("HTTPClient")
         expect(reg.require_paths).to eq(["httpclient"])
-        expect(reg.probe).to be_a(Skylight::Probes::HTTPClient::Probe)
+        expect(reg.probe).to be_a(Skylight::Probes::HTTPClientProbe::Probe)
       end
 
       it "wraps HTTPClient#do_request" do
         # This test is somewhat lame
-        expect(::HTTPClient.private_instance_methods).to include(:do_request_without_sk)
+        expect(HTTPClient.private_instance_methods).to include(:do_request_without_sk)
       end
 
     end


### PR DESCRIPTION
This is a PR to add a probe for [HTTPClient](https://github.com/nahi/httpclient). Since HTTPClient is not associated with Rails, it doesn't make sense to integrate ActiveSupport subscriptions with it.

I mostly patterned specs after those from the Net/HTTP probe.

Also I'm interested in instrumenting asynchronous requests later on, but my naiive first attempt (instrumenting a method that gets run in a child thread from within HTTPClient) failed. Any suggestions would be appreciated.