### PR TITLE
Don’t call `lookup_context` if it's not defined.

### DIFF
--- a/lib/skylight/probes/action_controller.rb
+++ b/lib/skylight/probes/action_controller.rb
@@ -8,14 +8,18 @@ module Skylight
             alias append_info_to_payload_without_sk append_info_to_payload
             def append_info_to_payload(payload)
               append_info_to_payload_without_sk(payload)
-              if respond_to?(:rendered_format)
-                rendered_mime = rendered_format
-              else
+
+              rendered_mime = if respond_to?(:rendered_format)
+                rendered_format
+              elsif respond_to?(:lookup_context)
                 format = lookup_context.formats.first
-                rendered_mime = Mime[format.to_sym] if format
+                Mime[format.to_sym] if format
               end
-              payload[:rendered_format] = rendered_mime.try(:ref)
-              payload[:variant] = request.respond_to?(:variant) ? request.variant : nil
+
+              if rendered_mime
+                payload[:rendered_format] = rendered_mime.try(:ref)
+                payload[:variant] = request.respond_to?(:variant) ? request.variant : nil
+              end
             end
           end
 


### PR DESCRIPTION
Don’t call `lookup_context` if it's not defined.

In `ActionController::Metal` subclasses it isn’t.