### PR TITLE
Add support for request throttling

### DIFF
--- a/lib/skylight/config.rb
+++ b/lib/skylight/config.rb
@@ -46,6 +46,7 @@ module Skylight
       "IGNORED_ENDPOINT" => :ignored_endpoint,
       "IGNORED_ENDPOINTS" => :ignored_endpoints,
       "ENABLE_SEGMENTS" => :enable_segments,
+      "THROTTLE_RATE" => :throttle_rate,
 
       # == Skylight Remote ==
       "AUTH_URL"                     => :auth_url,
@@ -539,6 +540,14 @@ authentication: #{self[:authentication]}
           val.concat(Array(ignored_endpoints))
           val
         end
+    end
+
+    # @api private
+    def throttle_rate
+      @throttle_rate ||=
+        begin
+          get(:throttle_rate)
+        end || 1
     end
 
     def root

--- a/lib/skylight/instrumenter.rb
+++ b/lib/skylight/instrumenter.rb
@@ -241,6 +241,11 @@ module Skylight
         return false
       end
 
+      if throttle?
+        t { fmt "throttling trace" }
+        return false
+      end
+
       begin
         native_submit_trace(trace)
         true
@@ -252,6 +257,10 @@ module Skylight
 
     def ignore?(trace)
       config.ignored_endpoints.include?(trace.endpoint)
+    end
+
+    def throttle?
+      @config.throttle_rate < 1 && Random.rand >= @config.throttle_rate
     end
 
   end

--- a/spec/unit/instrumenter_spec.rb
+++ b/spec/unit/instrumenter_spec.rb
@@ -369,6 +369,37 @@ describe "Skylight::Instrumenter", :http, :agent do
         expect(server.reports[0]).to have(1).endpoints
         expect(server.reports[0].endpoints.map(&:name)).to eq(["foo#bar"])
       end
+
+      it "ignores throttled traces" do
+        config[:throttle_rate] = 0.5
+
+        allow(Random).to receive(:rand).with(any_args).and_return(0.6)
+
+        Skylight.trace 'foo#bar', 'app.rack' do |t|
+          clock.skip 1
+        end
+
+        clock.unfreeze
+        server.wait
+
+        server.should have(0).reports
+      end
+
+      it "permits non-throttled traces" do
+        config[:throttle_rate] = 0.5
+
+        allow(Random).to receive(:rand).with(any_args).and_return(0.4)
+
+        Skylight.trace 'baz#qux', 'app.rack' do |t|
+          clock.skip 1
+        end
+
+        clock.unfreeze
+        server.wait(count: 3)
+
+        server.reports[0].should have(1).endpoints
+        server.reports[0].endpoints.map(&:name).should == ["baz#qux"]
+      end
     end
 
     def with_endpoint(endpoint)


### PR DESCRIPTION
This PR adds a config setting to control the percentage of requests to send to Skylight. It's useful in cases where you want to reduce network traffic.
