### PR TITLE
Two fixes for Elasticsearch

### DIFF
--- a/lib/skylight/normalizers/elasticsearch/request.rb
+++ b/lib/skylight/normalizers/elasticsearch/request.rb
@@ -12,7 +12,7 @@ module Skylight
           desc = {}
           desc[:type] = path[1] if path[1]
           desc[:id] = '?' if path[2]
-          [ CAT, title, desc.presence ]
+          [ CAT, title, desc.presence.try(:to_json) ]
         end
       end
     end

--- a/lib/skylight/probes/elasticsearch.rb
+++ b/lib/skylight/probes/elasticsearch.rb
@@ -11,13 +11,18 @@ module Skylight
                                                       method: method,
                                                       path:   path do
 
-                # Prevent Net::HTTP instrumenter from firing
-                Skylight::Probes::NetHTTP::Probe.disable do
-                  Skylight::Probes::HTTPClient::Probe.disable do
+                # Prevent HTTP-related probes from firing
+                disable_skylight_probe(:NetHTTP) do
+                  disable_skylight_probe(:HTTPClient) do
                     perform_request_without_sk(method, path, *args, &block)
                   end
                 end
               end
+            end
+
+            def disable_skylight_probe(class_name, &block)
+              klass = Skylight::Probes.const_get(class_name).const_get(:Probe) rescue nil
+              klass ? klass.disable(&block) : block.call
             end
           end
         end

--- a/spec/integration/probes/elasticsearch_spec.rb
+++ b/spec/integration/probes/elasticsearch_spec.rb
@@ -19,7 +19,7 @@ if ENV['TEST_ELASTICSEARCH_INTEGRATION']
       expect(current_trace).to receive(:instrument).with("db.elasticsearch.request", "PUT skylight-test", nil).and_call_original.once
       client.indices.create(index: 'skylight-test')
 
-      expect(current_trace).to receive(:instrument).with("db.elasticsearch.request", "PUT skylight-test", {type: 'person', id: '?'}).and_call_original.once
+      expect(current_trace).to receive(:instrument).with("db.elasticsearch.request", "PUT skylight-test", {type: 'person', id: '?'}.to_json).and_call_original.once
       client.index(index: 'skylight-test', type: 'person', id: '1', body: {name: 'Joe'})
     end
   end

--- a/spec/integration/probes/elasticsearch_spec.rb
+++ b/spec/integration/probes/elasticsearch_spec.rb
@@ -22,5 +22,27 @@ if ENV['TEST_ELASTICSEARCH_INTEGRATION']
       expect(current_trace).to receive(:instrument).with("db.elasticsearch.request", "PUT skylight-test", {type: 'person', id: '?'}.to_json).and_call_original.once
       client.index(index: 'skylight-test', type: 'person', id: '1', body: {name: 'Joe'})
     end
+
+    it "handles uninitialized probe dependencies" do
+      # Temporarily uninstall NetHTTP and HTTPClient probes
+      TempNetHTTPProbe    = Skylight::Probes::NetHTTP::Probe
+      TempHTTPClientProbe = Skylight::Probes::HTTPClient::Probe
+      Skylight::Probes::NetHTTP.send(:remove_const, :Probe)
+      Skylight::Probes::HTTPClient.send(:remove_const, :Probe)
+      allow_any_instance_of(::Net::HTTP).to receive(:request){|obj, *args| obj.send(:request_without_sk, *args)}
+      allow_any_instance_of(::HTTPClient).to receive(:do_request){|obj, *args| obj.send(:do_request_without_sk, *args)}
+
+      expect(current_trace).to receive(:instrument).with("db.elasticsearch.request", "PUT skylight-test", nil).and_call_original.once
+      client.indices.create(index: 'skylight-test')
+
+      expect(current_trace).to receive(:instrument).with("db.elasticsearch.request", "PUT skylight-test", {type: 'person', id: '?'}.to_json).and_call_original.once
+      client.index(index: 'skylight-test', type: 'person', id: '1', body: {name: 'Joe'})
+
+      # Restore NetHTTP and HTTPClient probe constants
+      Skylight::Probes::NetHTTP::Probe    = TempNetHTTPProbe
+      Skylight::Probes::HTTPClient::Probe = TempHTTPClientProbe
+      Object.send(:remove_const, :'TempNetHTTPProbe')
+      Object.send(:remove_const, :'TempHTTPClientProbe')
+    end
   end
 end

--- a/spec/unit/normalizers/elasticsearch_spec.rb
+++ b/spec/unit/normalizers/elasticsearch_spec.rb
@@ -14,7 +14,7 @@ module Skylight
       category, title, description = normalize(method: 'GET', path: 'foo/bar/baz')
       expect(category).to    eq("db.elasticsearch.request")
       expect(title).to       eq("GET foo")
-      expect(description).to eq({type: 'bar', id: '?'})
+      expect(description).to eq("{\"type\":\"bar\",\"id\":\"?\"}")
     end
   end
 end


### PR DESCRIPTION
- Fix error which is raised when you install ES probe without HTTPClient probe
- Fix type output of ES Normalizer; third element in the output array should be a JSON string not a Hash.