### PR TITLE
Fix assigned but unused variable warning

### DIFF
--- a/lib/skylight/config.rb
+++ b/lib/skylight/config.rb
@@ -552,7 +552,7 @@ authentication: #{self[:authentication]}
         deploy_str = deploy.to_query_string
         # A pipe should be a safe delimiter since it's not in the standard token
         # and is encoded by URI
-        token += "|#{deploy.to_query_string}"
+        token += "|#{deploy_str}"
       end
 
       token


### PR DESCRIPTION
Takes care of: `/Users/robin/.gem/ruby/2.3.3/gems/skylight-1.0.1/lib/skylight/config.rb:552: warning: assigned but unused variable - deploy_str`.

I have signed the CLA.