### PR TITLE
check for emptiness in addition to existence

### DIFF
--- a/lib/skylight/util/proxy.rb
+++ b/lib/skylight/util/proxy.rb
@@ -2,7 +2,8 @@ module Skylight
   module Util
     module Proxy
       def self.detect_url(env)
-        if u = env['HTTP_PROXY'] || env['http_proxy']
+        u = env['HTTP_PROXY'] || env['http_proxy']
+        if u && !u.empty?
           u = "http://#{u}" unless u =~ %r[://]
           u
         end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -594,10 +594,25 @@ module Skylight
         expect(c[:proxy_url]).to eq('http://bar.com:9872')
       end
 
+      it "uses unconvential proxy env vars" do
+        c = Config.load({environment: :production}, 'HTTP_PROXY' => 'xyz://foo.com:9872')
+        expect(c[:proxy_url]).to eq('xyz://foo.com:9872')
+      end
+
       it "normalizes convential proxy env vars" do
         # Curl doesn't require http:// prefix
         c = Config.load({environment: :production}, 'HTTP_PROXY' => 'foo.com:9872')
         expect(c[:proxy_url]).to eq('http://foo.com:9872')
+      end
+
+      it "skips empty proxy env vars" do
+        c = Config.load({environment: :production}, 'HTTP_PROXY' => '')
+        expect(c[:proxy_url]).to be_nil
+      end
+
+      it "skips nil proxy env vars" do
+        c = Config.load({environment: :production})
+        expect(c[:proxy_url]).to be_nil
       end
 
       it "prioritizes skylight's proxy env var" do


### PR DESCRIPTION
We had a set-but-empty `HTTP_PROXY` for some reason, and ended up with the proxy set to `http://`.

Checking the env var for emptiness is required here, but may also be required in `lib/skylight/config.rb` where this is used - `# Only set if it exists, we don't want to set to a nil value`.

CLA is signed, but my GH username has proven problematic before.