### PR TITLE
Add support for Coach via normalizers

### DIFF
--- a/lib/skylight/normalizers.rb
+++ b/lib/skylight/normalizers.rb
@@ -153,8 +153,6 @@ module Skylight
         active_record/sql
         active_support/cache
         elasticsearch/request
-        coach/handler_finish
-        coach/middleware_finish
         grape/endpoint
         moped/query
         faraday/request

--- a/lib/skylight/normalizers.rb
+++ b/lib/skylight/normalizers.rb
@@ -153,6 +153,8 @@ module Skylight
         active_record/sql
         active_support/cache
         elasticsearch/request
+        coach/handler_finish
+        coach/middleware_finish
         grape/endpoint
         moped/query
         faraday/request

--- a/lib/skylight/normalizers.rb
+++ b/lib/skylight/normalizers.rb
@@ -162,6 +162,13 @@ module Skylight
       require "skylight/normalizers/#{file}"
     end
 
+    # Coach instrumentation is only available in Ruby 2+
+    if RUBY_VERSION.split.first.to_i > 1
+      %w(coach/handler_finish coach/middleware_finish).each do |file|
+        require "skylight/normalizers/#{file}"
+      end
+    end
+
     # The following are not required by default as they are of dubious usefulness:
     # - active_job/enqueue_at
   end

--- a/lib/skylight/normalizers/coach/handler_finish.rb
+++ b/lib/skylight/normalizers/coach/handler_finish.rb
@@ -1,0 +1,52 @@
+module Skylight
+  module Normalizers
+    module Coach
+      class HandlerFinish < Normalizer
+        register "coach.handler.finish"
+
+        CAT = "app.coach.handler".freeze
+
+        # See information on the events Coach emits here:
+        # https://github.com/gocardless/coach#instrumentation
+
+        # Run when the handler first starts, we need to set the trace endpoint to be the
+        # handler name.
+        #
+        # We can expect the payload to have the :middleware key.
+        def normalize(trace, name, payload)
+          trace.endpoint = payload[:middleware]
+          [ CAT, payload[:middleware], nil ]
+        end
+
+        def normalize_after(trace, span, name, payload)
+          return unless config.enable_segments?
+
+          segments = []
+
+          response_status = payload.fetch(:response, {}).fetch(:status, '').to_s
+          segments << "error" if response_status.start_with?('4', '5')
+
+          segments.concat(extract_skylight_segments(payload))
+
+          if segments.any?
+            trace.endpoint += "<sk-segment>#{segments.join("+")}</sk-segment>"
+          end
+        end
+
+        private
+
+          # Coach provides a metadata logging facility which can be used to tag requests
+          # during execution. It's particularly useful for users to apply segments to the
+          # current Skylight trace by logging metadata with keys that have a
+          # skylight_segment_ prefix.
+          def extract_skylight_segments(payload)
+            metadata_keys = payload.fetch(:metadata, {}).keys
+            metadata_keys.map do |key|
+              match = key.to_s.match(/^skylight_segment_(\S+)/)
+              match && match[1]
+            end.compact
+          end
+      end
+    end
+  end
+end

--- a/lib/skylight/normalizers/coach/handler_finish.rb
+++ b/lib/skylight/normalizers/coach/handler_finish.rb
@@ -26,26 +26,10 @@ module Skylight
           response_status = payload.fetch(:response, {}).fetch(:status, '').to_s
           segments << "error" if response_status.start_with?('4', '5')
 
-          segments.concat(extract_skylight_segments(payload))
-
           if segments.any?
             trace.endpoint += "<sk-segment>#{segments.join("+")}</sk-segment>"
           end
         end
-
-        private
-
-          # Coach provides a metadata logging facility which can be used to tag requests
-          # during execution. It's particularly useful for users to apply segments to the
-          # current Skylight trace by logging metadata with keys that have a
-          # skylight_segment_ prefix.
-          def extract_skylight_segments(payload)
-            metadata_keys = payload.fetch(:metadata, {}).keys
-            metadata_keys.map do |key|
-              match = key.to_s.match(/^skylight_segment_(\S+)/)
-              match && match[1]
-            end.compact
-          end
       end
     end
   end

--- a/lib/skylight/normalizers/coach/middleware_finish.rb
+++ b/lib/skylight/normalizers/coach/middleware_finish.rb
@@ -1,0 +1,23 @@
+module Skylight
+  module Normalizers
+    module Coach
+      class MiddlewareFinish < Normalizer
+        register "coach.middleware.finish"
+
+        CAT = "app.coach.middleware".freeze
+
+        # See information on the events Coach emits here:
+        # https://github.com/gocardless/coach#instrumentation
+
+        # Called whenever a new middleware is executed. We can expect this to happen
+        # within a Coach::Handler.
+        #
+        # We can expect the payload to have the :middleware key.
+        def normalize(trace, name, payload)
+          trace.endpoint = payload[:middleware]
+          [ CAT, payload[:middleware], nil ]
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/normalizers/coach/handler_finish_spec.rb
+++ b/spec/unit/normalizers/coach/handler_finish_spec.rb
@@ -4,7 +4,9 @@ module Skylight
   describe "Normalizers", "coach.handler.finish", :agent do
 
     # Coach instrumentation is only available in Ruby 2+
-    skip unless RUBY_VERSION.split.first.to_i > 1
+    before :each do
+      skip "only available in Ruby 2+" unless RUBY_VERSION.split.first.to_i > 1
+    end
 
     let(:event) { { middleware: "Auth" } }
 

--- a/spec/unit/normalizers/coach/handler_finish_spec.rb
+++ b/spec/unit/normalizers/coach/handler_finish_spec.rb
@@ -21,14 +21,5 @@ module Skylight
       expect(trace.endpoint).to eq("Auth<sk-segment>error</sk-segment>")
     end
 
-    it "adds segment when Coach logs :skylight_segment_* key" do
-      normalize(event)
-      normalize_after(event.merge(
-        metadata: { random_key: true, skylight_segment_admin: true }
-      ))
-
-      expect(trace.endpoint).to eq("Auth<sk-segment>admin</sk-segment>")
-    end
-
   end
 end

--- a/spec/unit/normalizers/coach/handler_finish_spec.rb
+++ b/spec/unit/normalizers/coach/handler_finish_spec.rb
@@ -6,16 +6,6 @@ module Skylight
     # Coach instrumentation is only available in Ruby 2+
     skip unless RUBY_VERSION.split.first.to_i > 1
 
-    before :each do
-      @original_enable_segments = config.enable_segments?
-      config.set(:enable_segments, true)
-    end
-
-    after :each do
-      config.set(:enable_segments, @original_enable_segments)
-    end
-
-    let(:enable_segments) { false }
     let(:event) { { middleware: "Auth" } }
 
     it "updates the trace's endpoint" do

--- a/spec/unit/normalizers/coach/handler_finish_spec.rb
+++ b/spec/unit/normalizers/coach/handler_finish_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+module Skylight
+  describe "Normalizers", "coach.handler.finish", :agent do
+
+    before :each do
+      @original_enable_segments = config.enable_segments?
+      config.set(:enable_segments, true)
+    end
+
+    after :each do
+      config.set(:enable_segments, @original_enable_segments)
+    end
+
+    let(:enable_segments) { false }
+    let(:event) { { middleware: "Auth" } }
+
+    it "updates the trace's endpoint" do
+      expect(trace).to receive(:endpoint=).and_call_original
+      normalize(event)
+      expect(trace.endpoint).to eq("Auth")
+    end
+
+    it "adds segment when response is an error" do
+      normalize(event)
+      normalize_after(event.merge(response: { status: 500 }))
+
+      expect(trace.endpoint).to eq("Auth<sk-segment>error</sk-segment>")
+    end
+
+    it "adds segment when Coach logs :skylight_segment_* key" do
+      normalize(event)
+      normalize_after(event.merge(
+        metadata: { random_key: true, skylight_segment_admin: true }
+      ))
+
+      expect(trace.endpoint).to eq("Auth<sk-segment>admin</sk-segment>")
+    end
+
+  end
+end

--- a/spec/unit/normalizers/coach/handler_finish_spec.rb
+++ b/spec/unit/normalizers/coach/handler_finish_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 module Skylight
   describe "Normalizers", "coach.handler.finish", :agent do
 
+    # Coach instrumentation is only available in Ruby 2+
+    skip unless RUBY_VERSION.split.first.to_i > 1
+
     before :each do
       @original_enable_segments = config.enable_segments?
       config.set(:enable_segments, true)

--- a/spec/unit/normalizers/coach/middleware_finish_spec.rb
+++ b/spec/unit/normalizers/coach/middleware_finish_spec.rb
@@ -6,15 +6,6 @@ module Skylight
     # Coach instrumentation is only available in Ruby 2+
     skip unless RUBY_VERSION.split.first.to_i > 1
 
-    before :each do
-      @original_enable_segments = config.enable_segments?
-      config.set(:enable_segments, true)
-    end
-
-    after :each do
-      config.set(:enable_segments, @original_enable_segments)
-    end
-
     it "updates the trace's endpoint" do
       expect(trace).to receive(:endpoint=).and_call_original
       normalize(middleware: "Auth")

--- a/spec/unit/normalizers/coach/middleware_finish_spec.rb
+++ b/spec/unit/normalizers/coach/middleware_finish_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+module Skylight
+  describe "Normalizers", "coach.middleware.finish", :agent do
+
+    before :each do
+      @original_enable_segments = config.enable_segments?
+      config.set(:enable_segments, true)
+    end
+
+    after :each do
+      config.set(:enable_segments, @original_enable_segments)
+    end
+
+    it "updates the trace's endpoint" do
+      expect(trace).to receive(:endpoint=).and_call_original
+      normalize(middleware: "Auth")
+      expect(trace.endpoint).to eq("Auth")
+    end
+
+  end
+end

--- a/spec/unit/normalizers/coach/middleware_finish_spec.rb
+++ b/spec/unit/normalizers/coach/middleware_finish_spec.rb
@@ -4,7 +4,9 @@ module Skylight
   describe "Normalizers", "coach.middleware.finish", :agent do
 
     # Coach instrumentation is only available in Ruby 2+
-    skip unless RUBY_VERSION.split.first.to_i > 1
+    before :each do
+      skip "only available in Ruby 2+" unless RUBY_VERSION.split.first.to_i > 1
+    end
 
     it "updates the trace's endpoint" do
       expect(trace).to receive(:endpoint=).and_call_original

--- a/spec/unit/normalizers/coach/middleware_finish_spec.rb
+++ b/spec/unit/normalizers/coach/middleware_finish_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 module Skylight
   describe "Normalizers", "coach.middleware.finish", :agent do
 
+    # Coach instrumentation is only available in Ruby 2+
+    skip unless RUBY_VERSION.split.first.to_i > 1
+
     before :each do
       @original_enable_segments = config.enable_segments?
       config.set(:enable_segments, true)


### PR DESCRIPTION
Hey all! Some background to this change is that I work at [GoCardless](https://gocardless.com), where we use a middleware library called Coach inside a Rails app instead of standard controllers. It's an open-source library which you can find at github.com/gocardless/coach.

We use Skylight to profile our endpoints, but are currently relying on a small initializer to pick-up on Coach instrumentation events and call into the Skylight trace functions. While this works ok, we would prefer to have first class support built into the Skylight gem. This situation means other users of Coach can easily benefit, and all GoCardless apps can be instrumented by default.

I've added the required Normalizers here, in a style that I think is compatible with the library. If you feel this is valuable I would love to get feedback on things I may have missed- such as integration tests. Happy to make whatever changes you would need to get this merged!

---

This change introduces normalizers to process instrumentation events
from [Coach](https://github.com/gocardless/coach), a Ruby routing/middleware library.

Coach wraps middleware chains in a `Handler`, which will call each of the
middlewares in turn. The `Handler` instruments a `coach.handler.finish`
event, while each `Middleware` will instrument a `coach.middleware.finish`
event.

We hook into these events by setting the trace name on the first
`coach.handler.finish` event, then creating sub-traces for all the
different middlewares as they execute through the request. This produces
a stack trace in the Skylight dashboard that shows exactly how long each
middleware has taken to process.

This change also supports Skylight segments, and allows Coach users to
tag request traces with a segment:

```ruby
# This trace would be assigned an 'admin' segment, useful when it would
# be inappropriate to bundle certain requests together
class Middleware::Authenticate < Coach::Middleware
  def call
    log_metadata(skylight_segment_admin: true) if admin?
    next_middleware.call
  end

  ...
end
```