### PR TITLE
Change the Rails version detect

### DIFF
--- a/skylight-core/lib/skylight/core/probes/action_view.rb
+++ b/skylight-core/lib/skylight/core/probes/action_view.rb
@@ -10,11 +10,9 @@ module Skylight::Core
               layout = nil
 
               if path
-                if method(:find_layout).arity == 3
-                  # Rails 5
+                if ::ActionView.gem_version >= Gem::Version.new('5.x')
                   layout = find_layout(path, locals.keys, [formats.first])
                 else
-                  # Rails 4
                   layout = find_layout(path, locals.keys)
                 end
               end


### PR DESCRIPTION
**Describe**
Change the way to detecting the Rails version, this way is more clear.

**Motivation**
I use Spree, with changing the `find_layout ` method signature, but preserve the behaviour, so works as expected, and the current version of this gem, fail on the detection the Rails version.