### PR TITLE
don't rely on ActiveSupport's String#first

### DIFF
--- a/skylight-core/lib/skylight/core/middleware.rb
+++ b/skylight-core/lib/skylight/core/middleware.rb
@@ -124,7 +124,7 @@ module Skylight::Core
 
       def make_request_id(request_id)
         if request_id && !request_id.empty?
-          request_id.gsub(/[^\w\-]/, "".freeze).first(255)
+          request_id.gsub(/[^\w\-]/, "".freeze)[0...255]
         else
           internal_request_id
         end


### PR DESCRIPTION
As the title says. We are using Sinatra, and not using ActiveSupport globally, so in this place we received errors such as:

`undefined method 'first' for "8e87932e-71b4-4c36-8252-e6ca4155efc4":String`

This patch accesses the first 255 chars of the string without relying on ActiveSupport.

I have signed the CLA but the check seems to be broken.