### PR TITLE
Add rubygems version and semver compatibility badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Skylight Ruby Agent
 
+![Rubygems Version](https://img.shields.io/gem/v/skylight.svg)
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=skylight&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=skylight&package-manager=bundler&version-scheme=semver)
+
 Instrument your ruby application and send the data to the Skylight
 servers.
 


### PR DESCRIPTION
Adds a Rubygems version badge and a SemVer compatibility one (data for the later comes from Dependabot).

Here's what the badges look like:

![Rubygems Version](https://img.shields.io/gem/v/skylight.svg) [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=skylight&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=skylight&package-manager=bundler&version-scheme=semver)