### PR TITLE
Change way of checking ams version

### DIFF
--- a/skylight-core/lib/skylight/core/probes/active_model_serializers.rb
+++ b/skylight-core/lib/skylight/core/probes/active_model_serializers.rb
@@ -13,8 +13,8 @@ module Skylight::Core
             end
           end
 
-          if defined?(::ActiveModel::Serializer::VERSION)
-            version = Gem::Version.new(::ActiveModel::Serializer::VERSION)
+          if Gem.loaded_specs['active_model_serializers']
+            version = Gem.loaded_specs['active_model_serializers'].version
           end
 
           if !version || version < Gem::Version.new("0.5.0")


### PR DESCRIPTION
We are running ams 0.8.4 and getting version fails with

```
[17] pry(main)> ::ActiveModel::Serializer::VERSION
NameError: uninitialized constant ActiveModel::Serializer::VERSION
```

This pr changes the way the version is fetch to

```
[42] pry(main)> Gem.loaded_specs['active_model_serializers'].version
=> Gem::Version.new("0.8.4")
```