### PR TITLE
Make gem version badge link to rubygems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Skylight Ruby Agent
-
-![Rubygems Version](https://img.shields.io/gem/v/skylight.svg)
+[![Gem Version](https://badge.fury.io/rb/skylight.svg)](https://badge.fury.io/rb/skylight)
 [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=skylight&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=skylight&package-manager=bundler&version-scheme=semver)
 
 Instrument your ruby application and send the data to the Skylight


### PR DESCRIPTION
Also changed the version badge to the one you get from rubygems, more visually consistent with the other badge but I can change that back if you want to :)

![image](https://user-images.githubusercontent.com/606517/51373996-f1f82700-1b01-11e9-98e3-cca746a3df03.png)
