### PR TITLE
Require formatters http for the faraday

### DIFF
--- a/skylight-core/lib/skylight/core/normalizers/faraday/request.rb
+++ b/skylight-core/lib/skylight/core/normalizers/faraday/request.rb
@@ -1,3 +1,5 @@
+require 'skylight/core/formatters/http'
+
 module Skylight::Core
   module Normalizers
     module Faraday


### PR DESCRIPTION

Related issue:

```D, [2019-04-18T17:00:30.416307 #13841] DEBUG -- Skylight: out: cat=nil, title="request.faraday", desc=nil
E, [2019-04-18T17:00:30.421409 #13841] ERROR -- Skylight: Subscriber#start error; msg=uninitialized constant Skylight::Core::Normalizers::Faraday::Request::Formatters
D, [2019-04-18T17:00:30.421520 #13841] DEBUG -- Skylight: trace=#<Skylight::Trace:0x00007fb092ebbaa0>
D, [2019-04-18T17:00:30.421559 #13841] DEBUG -- Skylight: in:  name="request.faraday
```