### PR TITLE
Rename deprecated Coach events

### DIFF
--- a/skylight-core/lib/skylight/core/normalizers/coach/handler_finish.rb
+++ b/skylight-core/lib/skylight/core/normalizers/coach/handler_finish.rb
@@ -2,7 +2,7 @@ module Skylight::Core
   module Normalizers
     module Coach
       class HandlerFinish < Normalizer
-        register "coach.handler.finish"
+        register "finish_handler.coach"
 
         CAT = "app.coach.handler".freeze
 

--- a/skylight-core/lib/skylight/core/normalizers/coach/handler_finish.rb
+++ b/skylight-core/lib/skylight/core/normalizers/coach/handler_finish.rb
@@ -2,7 +2,17 @@ module Skylight::Core
   module Normalizers
     module Coach
       class HandlerFinish < Normalizer
-        register "finish_handler.coach"
+        begin
+          require "coach/version"
+          version = Gem::Version.new(::Coach::VERSION)
+        rescue LoadError # rubocop:disable Lint/HandleExceptions
+        end
+
+        if version && version < Gem::Version.new("1.0")
+          register "coach.handler.finish"
+        else
+          register "finish_handler.coach"
+        end
 
         CAT = "app.coach.handler".freeze
 

--- a/skylight-core/lib/skylight/core/normalizers/coach/middleware_finish.rb
+++ b/skylight-core/lib/skylight/core/normalizers/coach/middleware_finish.rb
@@ -2,7 +2,17 @@ module Skylight::Core
   module Normalizers
     module Coach
       class MiddlewareFinish < Normalizer
-        register "finish_middleware.coach"
+        begin
+          require "coach/version"
+          version = Gem::Version.new(::Coach::VERSION)
+        rescue LoadError # rubocop:disable Lint/HandleExceptions
+        end
+
+        if version && version < Gem::Version.new("1.0")
+          register "coach.middleware.finish"
+        else
+          register "finish_middleware.coach"
+        end
 
         CAT = "app.coach.middleware".freeze
 

--- a/skylight-core/lib/skylight/core/normalizers/coach/middleware_finish.rb
+++ b/skylight-core/lib/skylight/core/normalizers/coach/middleware_finish.rb
@@ -2,7 +2,7 @@ module Skylight::Core
   module Normalizers
     module Coach
       class MiddlewareFinish < Normalizer
-        register "coach.middleware.finish"
+        register "finish_middleware.coach"
 
         CAT = "app.coach.middleware".freeze
 

--- a/skylight-core/spec/unit/normalizers/coach/handler_finish_spec.rb
+++ b/skylight-core/spec/unit/normalizers/coach/handler_finish_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 module Skylight
-  describe "Normalizers", "coach.handler.finish", :agent do
+  describe "Normalizers", "finish_handler.coach", :agent do
     let(:event) { { middleware: "Auth" } }
 
     it "updates the trace's endpoint" do

--- a/skylight-core/spec/unit/normalizers/coach/middleware_finish_spec.rb
+++ b/skylight-core/spec/unit/normalizers/coach/middleware_finish_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 module Skylight
-  describe "Normalizers", "coach.middleware.finish", :agent do
+  describe "Normalizers", "finish_middleware.coach", :agent do
     it "updates the trace's endpoint" do
       expect(trace).to receive(:endpoint=).and_call_original
       normalize(middleware: "Auth")


### PR DESCRIPTION
The `coach.handler.finish` and `coach.middleware.finish` events have
been deprecated one year ago in favor of `finish_handler.coach` and
`finish_middleware.coach` (see gocardless/coach#47).

This changeset renames those two events accordingly.