### PR TITLE
Add Shrine normalizer

### DIFF
--- a/lib/skylight/normalizers.rb
+++ b/lib/skylight/normalizers.rb
@@ -145,7 +145,8 @@ module Skylight
         graphiti/resolve
         graphiti/render
         graphql/base
-        sequel/sql].each do |file|
+        sequel/sql
+        shrine].each do |file|
       require "skylight/normalizers/#{file}"
     end
   end

--- a/lib/skylight/normalizers/shrine.rb
+++ b/lib/skylight/normalizers/shrine.rb
@@ -1,0 +1,34 @@
+module Skylight
+  module Normalizers
+    class Shrine < Normalizer
+      TITLES = {
+        "upload.shrine"           => "Upload",
+        "download.shrine"         => "Download",
+        "open.shrine"             => "Open",
+        "exists.shrine"           => "Exists",
+        "delete.shrine"           => "Delete",
+        "metadata.shrine"         => "Metadata",
+        "mime_type.shrine"        => "MIME Type",
+        "image_dimensions.shrine" => "Image Dimensions",
+        "signature.shrine"        => "Signature",
+        "extension.shrine"        => "Extension",
+        "derivation.shrine"       => "Derivation",
+        "derivatives.shrine"      => "Derivatives",
+        "data_uri.shrine"         => "Data URI",
+        "remote_url.shrine"       => "Remote URL"
+      }.freeze
+
+      TITLES.each_key do |key|
+        register key
+      end
+
+      def normalize(_trace, name, _payload)
+        title = ["Shrine", TITLES[name]].join(" ")
+
+        cat = "app.#{name.split('.').reverse.join('.')}"
+
+        [cat, title, nil]
+      end
+    end
+  end
+end

--- a/spec/unit/normalizers/shrine_spec.rb
+++ b/spec/unit/normalizers/shrine_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+require "date"
+
+module Skylight::Core
+  describe "Normalizers", "*.shrine", :agent do
+    # This has the same behavior for all keys specified in
+    # Skylight::Core::Normalizers::Shrine::TITLES.
+    specify do
+      category, title, desc =
+        normalize("upload.shrine")
+
+      expect(category).to eq("app.shrine.upload")
+      expect(title).to eq("Shrine Upload")
+      expect(desc).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
[Shrine](https://github.com/shrinerb/shrine) has added a plugin for [instrumentation](https://github.com/shrinerb/shrine#logging) in version 2.19.0, which goes via ActiveSupport::Notifications. So I was thinking that it would be nice to add a normalizer for it in Skylight, akin to the ActiveStorage one.

I only had problems with testing it, as I had troubles activating Skylight in a non-Rails environment. I've created an app (`DZJxlbrBTeYt`), and tried running the following script:

```
$ gem install skylight shrine shrine-memory
```
```rb
ENV["SKYLIGHT_AUTHENTICATION"] = "<MY_SECRET>"

require "skylight"
require "active_support/all"
require "shrine"
require "shrine/storage/memory"

Skylight.start!
Skylight.enable_normalizer("shrine")

Shrine.storages[:memory] = Shrine::Storage::Memory.new

Shrine.plugin :instrumentation

uploaded_file = Shrine.upload(StringIO.new, :memory)
uploaded_file.exists?
uploaded_file.download
uploaded_file.delete
```

But I don't see any events in my Skylight dashboard, even though Shrine did send out the events via `ActiveSupport::Notifications`.