### PR TITLE
Modified skylight/helpers to remove ruby 2.7 warnings about kwargs

### DIFF
--- a/lib/skylight/helpers.rb
+++ b/lib/skylight/helpers.rb
@@ -156,7 +156,13 @@ module Skylight
                                                                         #
               meta = {}                                                 #   meta = {}
               begin                                                     #   begin
-                send(:before_instrument_#{name}, *args, **opts, &blk)   #     send(:before_instrument_process, *args, **opts, &blk)
+                # In Ruby <2.7 sending empty kwargs to a method that    #
+                # doesn't take them will error                          #
+                if opts.empty?                                          #     if opts.empty?
+                  send(:before_instrument_#{name}, *args, &blk)         #       send(:before_instrument_process, *args, &blk)
+                else                                                    #     else
+                  send(:before_instrument_#{name}, *args, **opts, &blk) #       send(:before_instrument_process, *args, **opts, &blk)
+                end                                                     #     end
               rescue Exception => e                                     #   rescue Exception => e
                 meta[:exception_object] = e                             #     meta[:exception_object] = e
                 raise e                                                 #     raise e


### PR DESCRIPTION
This is really a boy-scout refactor. Optimally there would be a PR to address the whole gem for the 2.7 warnings, but I wanted to get this out there because we use the `instrument_method` helper in our apps and are allergic to `warning:` in our logs 😅.

I didn't find specific tests around the instrument method helper, but (at least locally), the tests as a whole passed for me.

Let me know if I'm way off on this or if it's just not something on your radar at the moment 👍 