### PR TITLE
Sampling feature

### DIFF
--- a/lib/skylight/config.rb
+++ b/lib/skylight/config.rb
@@ -56,6 +56,7 @@ module Skylight
       -"IGNORED_ENDPOINTS"            => :ignored_endpoints,
       -"SINATRA_ROUTE_PREFIXES"       => :sinatra_route_prefixes,
       -"ENABLE_SOURCE_LOCATIONS"      => :enable_source_locations,
+      -"SAMPLE_RATE"                  => :sample_rate,
 
       # == Max Span Handling ==
       -"REPORT_MAX_SPANS_EXCEEDED"    => :report_max_spans_exceeded,
@@ -522,6 +523,14 @@ module Skylight
           val.concat(Array(ignored_endpoints))
           val
         end
+    end
+
+    # @api private
+    def sample_rate
+      @sample_rate ||=
+        begin
+          get(:sample_rate)
+        end || 1
     end
 
     # @api private

--- a/lib/skylight/instrumenter.rb
+++ b/lib/skylight/instrumenter.rb
@@ -297,6 +297,11 @@ module Skylight
         return false
       end
 
+      unless sample?
+        t { fmt "non-sampled trace=#{trace.uuid}" }
+        return false
+      end
+
       begin
         finalize_endpoint_segment(trace)
         native_submit_trace(trace)
@@ -342,6 +347,10 @@ module Skylight
                 end
 
       trace.endpoint += "<sk-segment>#{segment}</sk-segment>"
+    end
+
+    def sample?
+      @config.sample_rate >= 1 || Random.rand <= @config.sample_rate
     end
   end
 end


### PR DESCRIPTION
This PR adds support for sampling which is supported in almost every other tracing lib on the planet. Sampling is useful to reduce noise and network traffic. Please refer to OpenTelemetry's docs here:

https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md