### PR TITLE
Stop using fiber-local variables

### DIFF
--- a/lib/skylight/instrumenter.rb
+++ b/lib/skylight/instrumenter.rb
@@ -17,22 +17,22 @@ module Skylight
       end
 
       def current
-        Thread.current[@key]
+        Thread.current.thread_variable_get(@key)
       end
 
       def current=(trace)
-        Thread.current[@key] = trace
+        Thread.current.thread_variable_set(@key, trace)
       end
 
       # NOTE: This should only be set by the instrumenter, and only
       # in the context of a `mute` block. Do not try to turn this
       # flag on and off directly.
       def muted=(val)
-        Thread.current[@muted_key] = val
+        Thread.current.thread_variable_set(@muted_key, val)
       end
 
       def muted?
-        !!Thread.current[@muted_key]
+        !!Thread.current.thread_variable_get(@muted_key)
       end
     end
 

--- a/lib/skylight/normalizers/faraday/request.rb
+++ b/lib/skylight/normalizers/faraday/request.rb
@@ -9,15 +9,15 @@ module Skylight
         DISABLED_KEY = :__skylight_faraday_disabled
 
         def self.disable
-          old_value = Thread.current[DISABLED_KEY]
-          Thread.current[DISABLED_KEY] = true
+          old_value = Thread.current.thread_variable_get(DISABLED_KEY)
+          Thread.current.thread_variable_set(DISABLED_KEY, true)
           yield
         ensure
-          Thread.current[DISABLED_KEY] = old_value
+          Thread.current.thread_variable_set(DISABLED_KEY, old_value)
         end
 
         def disabled?
-          !!Thread.current[DISABLED_KEY]
+          !!Thread.current.thread_variable_get(DISABLED_KEY)
         end
 
         def normalize(_trace, _name, payload)

--- a/lib/skylight/probes/httpclient.rb
+++ b/lib/skylight/probes/httpclient.rb
@@ -22,15 +22,15 @@ module Skylight
         DISABLED_KEY = :__skylight_httpclient_disabled
 
         def self.disable
-          old_value = Thread.current[DISABLED_KEY]
-          Thread.current[DISABLED_KEY] = true
+          old_value = Thread.current.thread_variable_get(DISABLED_KEY)
+          Thread.current.thread_variable_set(DISABLED_KEY, true)
           yield
         ensure
-          Thread.current[DISABLED_KEY] = old_value
+          Thread.current.thread_variable_set(DISABLED_KEY, old_value)
         end
 
         def self.disabled?
-          !!Thread.current[DISABLED_KEY]
+          !!Thread.current.thread_variable_get(DISABLED_KEY)
         end
 
         def install

--- a/lib/skylight/probes/net_http.rb
+++ b/lib/skylight/probes/net_http.rb
@@ -32,15 +32,15 @@ module Skylight
         DISABLED_KEY = :__skylight_net_http_disabled
 
         def self.disable
-          state_was = Thread.current[DISABLED_KEY]
-          Thread.current[DISABLED_KEY] = true
+          state_was = Thread.current.thread_variable_get(DISABLED_KEY)
+          Thread.current.thread_variable_set(DISABLED_KEY, true)
           yield
         ensure
-          Thread.current[DISABLED_KEY] = state_was
+          Thread.current.thread_variable_set(DISABLED_KEY, state_was)
         end
 
         def self.disabled?
-          !!Thread.current[DISABLED_KEY]
+          !!Thread.current.thread_variable_get(DISABLED_KEY)
         end
 
         def install


### PR DESCRIPTION
GraphQL added a [fiber-based batch loading API](https://github.com/rmosolgo/graphql-ruby/pull/3264) in one of their recent releases. Since the GraphQL execution is happening inside fibers and skylight is using fiber-local variables  in the instrumenter to keep track of the current trace, it's pretty much breaking tracing inside the GraphQL runtime.

To fix this I changed the usage of fiber-local variables to thread-local. We're currently using this in production and it _looks_ good. 

I've thrown together a [little app](https://github.com/check24-profis/skylight-fibers) that I used for testing. I will also provide a link to one of our endpoints in the in-app messenger. I've been already talking to @zvkemp about this there.