### PR TITLE
Mention updated GLIBC requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ instrumentation
 * [BUGFIX] Require http formatters for Faraday (thanks, @serkin!)
 * [BREAKING] Drop support for Ruby 2.2 since it is EOL
 * [BREAKING] New method for assigning 'segment' to a trace endpoint name
+* [BREAKING] Requires GLIBC 2.18 at minimum
 
 ## 3.1.4 (January 24, 2019)
 


### PR DESCRIPTION
Version 5.0.x of skylight requires GLIBC 2.18.
It used to require 2.15.

If you don't have 2.18+, this exhibits as "skylight doctor" failures: "Unable to load native extension: Reason unknown"