### PR TITLE
Handle case insensitive directory names

### DIFF
--- a/lib/skylight/probes.rb
+++ b/lib/skylight/probes.rb
@@ -83,6 +83,7 @@ module Skylight
           .glob(root.join("./**/*.rb"))
           .each do |f|
             name = f.relative_path_from(root).sub_ext("").to_s
+            name = name.gsub(/.*skylight\/core\/probes\//, "")
             raise "duplicate probe name: #{name}; original=#{available[name]}; new=#{f}" if available.key?(name)
 
             available[name] = f


### PR DESCRIPTION
I have chosen to install my gems locally, by setting `.gems` into
`.rbenv-gemsets`.

This caused a bug in skylight.
`add_path(File.expand_path("./probes", __dir__))` will call add_path with
`/Users/Aleksander/dev/work/snotr/server/.gems/gems/skylight-core-4.2.3/lib/skylight/core/probes`
and inside add_path we do `Pathname.glob(root.join("./**/*.rb"))`
and then one file returned is for example:
`/Users/aleksander/dev/work/snotr/server/.gems/gems/skylight-core-4.2.3/lib/skylight/core/probes/grape.rb`

name var in my case would become:
`../../../../../../../../../../../../aleksander/dev/work/snotr/server/.gems/gems/skylight-core-4.2.3/lib/skylight/core/probes/grape`

and then graphql probe would not be found.

Notice the difference in the first letter of the username. That causes
the problem. I did not find a good reason why this happens only when you
install local gems. The mac os can run on case sensitive or case
insensitive file systems, there are also linux distros running on both.
Maybe its an issue bundler or rbenv could solvem, but I think skylight
should solve this.


I would like help with determining a couple of things:
- Is this something you would accept a fix for, or do you think i should fix it outside this gem somehow?
- Do you want me to try making a "cleaner" fix?
- Do you have a suggestion on where i would add a spec for this?
