### PR TITLE
Avoid `Pathname#relative_path_from`

### DIFF
--- a/lib/skylight/probes.rb
+++ b/lib/skylight/probes.rb
@@ -78,15 +78,14 @@ module Skylight
       end
 
       def add_path(path)
-        root = Pathname.new(path)
-        Pathname
-          .glob(root.join("./**/*.rb"))
-          .each do |f|
-            name = f.relative_path_from(root).sub_ext("").to_s
-            raise "duplicate probe name: #{name}; original=#{available[name]}; new=#{f}" if available.key?(name)
+        Dir.glob("**/*.rb", base: path) do |f|
+          name = Pathname.new(f).sub_ext("").to_s
+          full_path = File.expand_path(f, path)
 
-            available[name] = f
-          end
+          raise "duplicate probe name: #{name}; original=#{available[name]}; new=#{full_path}" if available.key?(name)
+
+          available[name] = full_path
+        end
       end
 
       def available


### PR DESCRIPTION
`Pathname#relative_path_from` is potentially unreliable on macOS.

The macOS file system is case-insensitive by default, but for some reason `File::FNM_SYSCASE` is 0 (not caseg-sensitive). This cases `Pathname::SAME_PATHS` (which is used by `Pathname#relative_path_from` to do case sensitive comparisons.

If we end up getting paths that are not case-normalized, then we could potentially get strange results.

For example:

```rb
require 'pathname'

root = Pathname.new("/Some/wHeRe/")
path = Pathname.new("/some/where/foo.rb")

path.relative_path_from(root) # => Pathname.new("../../some/where/foo.rb")
```

This is hard to fix in the general case, but in here we don't actually need to rely on the functionality, as `Dir.glob` (which is used by `Pathname::glob` internally) already takes a `base:` named argument, and returns path relative to the base by default.

Closes #390

