### PR TITLE
Add abbrev and base64 as explicit dependencies

### DIFF
--- a/skylight.gemspec
+++ b/skylight.gemspec
@@ -27,7 +27,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Dependencies
+  spec.add_dependency "abbrev"
   spec.add_dependency "activesupport", ">= 5.2.0"
+  spec.add_dependency "base64"
 
   spec.add_development_dependency "beefcake", "~> 1.0"
   spec.add_development_dependency "bundler", ">= 1.17.3"


### PR DESCRIPTION
```
~ $ bundle exec skylight doctor
/app/vendor/bundle/ruby/3.3.0/gems/activesupport-7.0.8/lib/active_support/notifications/fanout.rb:3: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec. Also contact author of activesupport-7.0.8 to add mutex_m into its gemspec.
/app/vendor/bundle/ruby/3.3.0/gems/skylight-5.1.1/lib/skylight/probes.rb:167: warning: abbrev was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add abbrev to your Gemfile or gemspec. Also contact author of skylight-5.1.1 to add abbrev into its gemspec.
Checking SSL
/app/vendor/bundle/ruby/3.3.0/gems/skylight-5.1.1/lib/skylight/probes.rb:167: warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec. Also contact author of skylight-5.1.1 to add base64 into its gemspec.
  OK
```

