### PR TITLE
[Test WIP] Allow to configure min/max trace duration of ignored endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+- [IMPROVEMENT] Support for configuring optional min/max duration thresholds values with ignored endpoints
+
 ## 6.1.0.beta (June 11, 2024)
 
 - [IMPROVEMENT] Initial support for parsing queries from activerecord-sqlserver-adapter

--- a/lib/skylight/instrumenter.rb
+++ b/lib/skylight/instrumenter.rb
@@ -352,8 +352,9 @@ module Skylight
 
         # trace endpoint matches configured endpoint. Check min and max durations and return
         ignored_endpoint.match(/:(?<min_duration>\d*)(:(?<max_duration>\d*))?$/) do |m|
-          min_duration = m[:min_duration].to_i
-          max_duration = m[:max_duration].to_i
+          # note: trace duration is in tenths of milliseconds while config is in milliseconds
+          min_duration = m[:min_duration].to_i * 10
+          max_duration = m[:max_duration].to_i * 10
 
           # Do not ignore if trace duration is within the configured min/max range
           return false if trace.duration >= min_duration && (!max_duration.positive? || trace.duration <= max_duration)

--- a/lib/skylight/trace.rb
+++ b/lib/skylight/trace.rb
@@ -44,6 +44,7 @@ module Skylight
 
       # create the root node
       @root = start(native_get_started_at, cat, title, desc, meta, normalize: false)
+      @duration = 0
 
       # Also store meta for later access
       @meta = meta
@@ -70,6 +71,10 @@ module Skylight
 
     def too_many_spans?
       !!@too_many_spans
+    end
+
+    def duration
+      @duration
     end
 
     def log_context
@@ -188,6 +193,7 @@ module Skylight
 
       gc = gc_time
       now = Skylight::Util::Clock.nanos
+      @duration = self.class.normalize_time(now) - native_get_started_at
       track_gc(gc, now)
       stop(@root, now)
     end


### PR DESCRIPTION
Testing a proof of concept for now - I needed to ignore very frequently called endpoints UNLESS they take a lot of time and then see what they do.

Syntax is: `ClassName#method_name[:<min>[:<max>]]`, where `min` and `max` are in milliseconds.

Examples:
```yaml
ignore_endpoints:
- MyController#my_action # ignore this endpoint
- MyController#my_other_action:500 # ignore this endpoint when processing duration is < 0.5s
- MyController#another_action:200:6000 # ignore this endpoint when processing duration is < 0.2s or > 6s
- MyController#another_action:0:1000 # ignore this endpoint when processing duration is > 1s
```